### PR TITLE
Update sendywpcf.php

### DIFF
--- a/sendywpcf/sendywpcf.php
+++ b/sendywpcf/sendywpcf.php
@@ -18,7 +18,8 @@ add_action('init', 'sendywpcf_init');
 function sendywpcf_init() {
 
 	add_action( 'wpcf7_mail_sent', 'subscribe_from_cf7');
-	if (!function_exists('wpcf7_add_shortcode')) {
+	// wpcf7_add_shortcode Depricated, replaced with wpcf7_add_form_tag
+	if (!function_exists('wpcf7_add_form_tag')) {
 		return false;
 	}
 	wpcf7_add_shortcode('sendywpcf', 'get_list_id');


### PR DESCRIPTION
Contact form 7 upgrades.
wpcf7_add_shortcode() is deprecated in 4.6. 
See http://contactform7.com/2016/12/03/contact-form-7-46/